### PR TITLE
feat: add helper to build conservative cam map

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -266,6 +266,40 @@ export default function CombustionTrainer() {
   const [tuningOn, setTuningOn] = useState(false);
   const [camMap, setCamMap] = useState({}); // { percent: { fuel, air } }
 
+  // Excess air profiles for auto-generated cam maps
+  const EXCESS_AIR_PROFILES = {
+    "Natural Gas": [0, 1.4, 1.35, 1.32, 1.29, 1.26, 1.24, 1.23, 1.22, 1.21, 1.2],
+    Propane: [0, 1.4, 1.35, 1.32, 1.29, 1.26, 1.24, 1.23, 1.22, 1.21, 1.2],
+    "Fuel Oil #2": [0, 1.45, 1.4, 1.35, 1.32, 1.3, 1.28, 1.26, 1.24, 1.22, 1.2],
+    Biodiesel: [0, 1.45, 1.4, 1.35, 1.32, 1.3, 1.28, 1.26, 1.24, 1.22, 1.2],
+  };
+
+  // Build a conservative cam map using stoichiometric air requirements
+  function BuildSafeCamMap(fuelKey, minFuel, maxFuel) {
+    const { C, H, O } = FUELS[fuelKey].formula;
+    const profile = EXCESS_AIR_PROFILES[fuelKey] || EXCESS_AIR_PROFILES["Natural Gas"];
+    const map = {};
+
+    for (let pct = 0; pct <= 100; pct += 10) {
+      if (pct === 0) {
+        map[pct] = { fuel: 0, air: 0 };
+        continue;
+      }
+      const t = (pct - 10) / 90; // 0 at 10%, 1 at 100%
+      const fuel = clamp(lerp(minFuel, maxFuel, t), minFuel, maxFuel);
+      const O2_needed = fuel * (C + H / 4 - O / 2);
+      const airStoich = O2_needed / 0.21;
+      const ea = profile[pct / 10] ?? 1.2;
+      const air = airStoich * ea;
+      map[pct] = {
+        fuel: Number(fuel.toFixed(2)),
+        air: Number(air.toFixed(2)),
+      };
+    }
+
+    return map;
+  }
+
   // Current cam position key (rounded to 10%)
   const currentCam = useMemo(() => clamp(Math.round(rheostat / 10) * 10, 0, 100), [rheostat]);
 


### PR DESCRIPTION
## Summary
- add excess-air profiles for each fuel
- implement helper to build safe cam map based on stoichiometric air

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 7 errors, 2 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6896bd1a45d4832aa357f53ccffcb2f3