### PR TITLE
Fix COAirFree reference and missing import

### DIFF
--- a/src/lib/cam.js
+++ b/src/lib/cam.js
@@ -1,4 +1,5 @@
 import { clamp, lerp } from "./math";
+import { OXYGEN_IN_AIR_FRACTION } from "./chemistry";
 
 export const EXCESS_AIR_PROFILES = {
   "Natural Gas": [0, 1.4, 1.35, 1.32, 1.29, 1.26, 1.24, 1.23, 1.22, 1.21, 1.2],

--- a/src/lib/chemistry.js
+++ b/src/lib/chemistry.js
@@ -75,7 +75,7 @@ export function computeCombustion({ fuel, fuelFlow, airFlow, stackTempF, ambient
     underTemp: stackTempF < 180,
   };
 
-  const CO_airfree = COAirFree(CO_ppm, O2_pct);
+  const CO_airfree = coAirFree(CO_ppm, O2_pct);
 
   return {
     O2_pct: Number(O2_pct.toFixed(2)),


### PR DESCRIPTION
## Summary
- Fix COAirFree function call in chemistry library to match the defined name
- Import OXYGEN_IN_AIR_FRACTION into cam module for calculation

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689955f63724832ab08440f8228f53f1