### PR TITLE
Add series visibility controls to trend chart

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -880,46 +880,80 @@ const rheostatRampRef = useRef(null);
                     <YAxis yAxisId="right" orientation="right" domain={[0, 600]} />
                     <Tooltip />
                     <Legend />
-                    <Line
-                      yAxisId="left"
-                      type="monotone"
-                      dataKey="O2"
-                      dot={false}
-                      name="O₂ %"
-                      strokeWidth={2}
-                      isAnimationActive={false}
-                    />
-                    <Line
-                      yAxisId="left"
-                      type="monotone"
-                      dataKey="CO2"
-                      dot={false}
-                      name="CO₂ %"
-                      strokeWidth={2}
-                      isAnimationActive={false}
-                    />
-                    <Line
-                      yAxisId="right"
-                      type="monotone"
-                      dataKey="StackF"
-                      dot={false}
-                      name="Stack °F"
-                      strokeWidth={2}
-                      isAnimationActive={false}
-                    />
-                    <Line
-                      yAxisId="left"
-                      type="monotone"
-                      dataKey="Eff"
-                      dot={false}
-                      name="Eff %"
-                      strokeWidth={2}
-                      isAnimationActive={false}
-                    />
+                    {seriesVisibility.O2 && (
+                      <Line
+                        yAxisId="left"
+                        type="monotone"
+                        dataKey="O2"
+                        dot={false}
+                        name="O₂ %"
+                        strokeWidth={2}
+                        isAnimationActive={false}
+                      />
+                    )}
+                    {seriesVisibility.CO2 && (
+                      <Line
+                        yAxisId="left"
+                        type="monotone"
+                        dataKey="CO2"
+                        dot={false}
+                        name="CO₂ %"
+                        strokeWidth={2}
+                        isAnimationActive={false}
+                      />
+                    )}
+                    {seriesVisibility.CO && (
+                      <Line
+                        yAxisId="right"
+                        type="monotone"
+                        dataKey="CO"
+                        dot={false}
+                        name="CO ppm"
+                        strokeWidth={2}
+                        isAnimationActive={false}
+                      />
+                    )}
+                    {seriesVisibility.NOx && (
+                      <Line
+                        yAxisId="right"
+                        type="monotone"
+                        dataKey="NOx"
+                        dot={false}
+                        name="NOₓ ppm"
+                        strokeWidth={2}
+                        isAnimationActive={false}
+                      />
+                    )}
+                    {seriesVisibility.StackF && (
+                      <Line
+                        yAxisId="right"
+                        type="monotone"
+                        dataKey="StackF"
+                        dot={false}
+                        name="Stack °F"
+                        strokeWidth={2}
+                        isAnimationActive={false}
+                      />
+                    )}
+                    {seriesVisibility.Eff && (
+                      <Line
+                        yAxisId="left"
+                        type="monotone"
+                        dataKey="Eff"
+                        dot={false}
+                        name="Eff %"
+                        strokeWidth={2}
+                        isAnimationActive={false}
+                      />
+                    )}
                   </LineChart>
                 </ResponsiveContainer>
               </div>
             </div>
+            <SeriesVisibility
+              visibility={seriesVisibility}
+              setVisibility={setSeriesVisibility}
+            />
             <div className="card">
               <div className="label">Clock the Boiler (Metering)</div>
               <div className="flex gap-2 mt-2">

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -880,71 +880,19 @@ const rheostatRampRef = useRef(null);
                     <YAxis yAxisId="right" orientation="right" domain={[0, 600]} />
                     <Tooltip />
                     <Legend />
-                    {seriesVisibility.O2 && (
-                      <Line
-                        yAxisId="left"
-                        type="monotone"
-                        dataKey="O2"
-                        dot={false}
-                        name="O₂ %"
-                        strokeWidth={2}
-                        isAnimationActive={false}
-                      />
-                    )}
-                    {seriesVisibility.CO2 && (
-                      <Line
-                        yAxisId="left"
-                        type="monotone"
-                        dataKey="CO2"
-                        dot={false}
-                        name="CO₂ %"
-                        strokeWidth={2}
-                        isAnimationActive={false}
-                      />
-                    )}
-                    {seriesVisibility.CO && (
-                      <Line
-                        yAxisId="right"
-                        type="monotone"
-                        dataKey="CO"
-                        dot={false}
-                        name="CO ppm"
-                        strokeWidth={2}
-                        isAnimationActive={false}
-                      />
-                    )}
-                    {seriesVisibility.NOx && (
-                      <Line
-                        yAxisId="right"
-                        type="monotone"
-                        dataKey="NOx"
-                        dot={false}
-                        name="NOₓ ppm"
-                        strokeWidth={2}
-                        isAnimationActive={false}
-                      />
-                    )}
-                    {seriesVisibility.StackF && (
-                      <Line
-                        yAxisId="right"
-                        type="monotone"
-                        dataKey="StackF"
-                        dot={false}
-                        name="Stack °F"
-                        strokeWidth={2}
-                        isAnimationActive={false}
-                      />
-                    )}
-                    {seriesVisibility.Eff && (
-                      <Line
-                        yAxisId="left"
-                        type="monotone"
-                        dataKey="Eff"
-                        dot={false}
-                        name="Eff %"
-                        strokeWidth={2}
-                        isAnimationActive={false}
-                      />
+                    {seriesConfig.map((series) =>
+                      seriesVisibility[series.key] && (
+                        <Line
+                          key={series.key}
+                          yAxisId={series.yAxisId}
+                          type="monotone"
+                          dataKey={series.key}
+                          dot={false}
+                          name={series.name}
+                          strokeWidth={2}
+                          isAnimationActive={false}
+                        />
+                      )
                     )}
                   </LineChart>
                 </ResponsiveContainer>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -35,6 +35,16 @@ import { useUIState } from "./components/UIStateContext";
  * @param {number} props.intensity - 0–1 scale controlling size/brightness.
  * @param {boolean} [props.pilot=false] - Render a smaller pilot flame.
  */
+
+const seriesConfig = [
+  { key: 'O2', name: 'O₂ %', yAxisId: 'left' },
+  { key: 'CO2', name: 'CO₂ %', yAxisId: 'left' },
+  { key: 'CO', name: 'CO ppm', yAxisId: 'right' },
+  { key: 'NOx', name: 'NOₓ ppm', yAxisId: 'right' },
+  { key: 'StackF', name: 'Stack °F', yAxisId: 'right' },
+  { key: 'Eff', name: 'Eff %', yAxisId: 'left' },
+];
+
 function Flame({ phi, intensity, pilot = false }) {
   let color = "#48b3ff"; // lean -> blue
   if (phi > 1.05 && phi < 1.2) color = "#ff8c00"; // near stoich -> orange


### PR DESCRIPTION
## Summary
- Allow toggling of individual data series on the trend chart
- Display series visibility controls beneath the graph

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a690853e8832aa0dad7de97fc7699