### PR TITLE
feat: add configurable settings menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,20 @@ root
 - `npm run build` — production build  
 - `npm run preview` — preview the built app
 
+## Settings
+
+Open **Settings** from the gear icon in the header or the Technician drawer.
+Sections include:
+
+- **General** — theme, default view, and trend history length.
+- **Analyzer** — sampling interval and reminders.
+- **Units** — choose imperial or metric display units.
+- **Ambient** — placeholders for live ambient data providers.
+- **Data and privacy** — note that CSV export and import buttons will move here later.
+
+Changes persist to `localStorage` under the `app_config_v1` key. Use
+**Restore defaults** within a section to reset just that section's values.
+
 ## Notes & limitations
 
 - This is an **instructional** model; values are tuned for trends/intuition, not absolute accuracy.

--- a/src/components/SettingsMenu.jsx
+++ b/src/components/SettingsMenu.jsx
@@ -1,5 +1,10 @@
 import React, { useEffect, useRef, useState } from "react";
 import { getDefaultConfig } from "../lib/config";
+import GeneralSection from "./settings/GeneralSection.jsx";
+import AnalyzerSection from "./settings/AnalyzerSection.jsx";
+import UnitsSection from "./settings/UnitsSection.jsx";
+import AmbientSection from "./settings/AmbientSection.jsx";
+import DataSection from "./settings/DataSection.jsx";
 
 export default function SettingsMenu({ open, config, onApply, onCancel }) {
   const [local, setLocal] = useState(config);
@@ -42,13 +47,13 @@ export default function SettingsMenu({ open, config, onApply, onCancel }) {
     return () => document.removeEventListener("keydown", handleKey);
   }, [open, onCancel]);
 
-  const sections = [
-    { key: "general", label: "General" },
-    { key: "analyzer", label: "Analyzer" },
-    { key: "units", label: "Units" },
-    { key: "ambient", label: "Ambient" },
-    { key: "data", label: "Data and privacy" },
-  ];
+  const sections = {
+    general: { label: "General", Component: GeneralSection },
+    analyzer: { label: "Analyzer", Component: AnalyzerSection },
+    units: { label: "Units", Component: UnitsSection },
+    ambient: { label: "Ambient", Component: AmbientSection },
+    data: { label: "Data and privacy", Component: DataSection },
+  };
 
   const handleField = (sec, field, value) => {
     setLocal((p) => ({ ...p, [sec]: { ...p[sec], [field]: value } }));
@@ -60,159 +65,7 @@ export default function SettingsMenu({ open, config, onApply, onCancel }) {
     setLocal((p) => ({ ...p, [section]: defaults[section] }));
   };
 
-  const renderSection = () => {
-    switch (section) {
-      case "general":
-        return (
-          <div className="space-y-4">
-            <label className="block text-sm">
-              Theme
-              <select
-                className="mt-1 border rounded-md px-2 py-1 w-full"
-                value={local.general.theme}
-                onChange={(e) => handleField("general", "theme", e.target.value)}
-              >
-                <option value="light">Light</option>
-                <option value="dark">Dark</option>
-                <option value="system">System</option>
-              </select>
-            </label>
-            <label className="block text-sm">
-              Default view
-              <select
-                className="mt-1 border rounded-md px-2 py-1 w-full"
-                value={local.general.defaultView}
-                onChange={(e) => handleField("general", "defaultView", e.target.value)}
-              >
-                <option value="main">Main</option>
-                <option value="techDrawer">Technician drawer</option>
-              </select>
-            </label>
-            <label className="block text-sm">
-              Trend length (samples)
-              <input
-                type="number"
-                className="mt-1 border rounded-md px-2 py-1 w-full"
-                value={local.general.trendLength}
-                onChange={(e) =>
-                  handleField("general", "trendLength", parseInt(e.target.value || 0, 10))
-                }
-              />
-              {local.general.trendLength < 60 || local.general.trendLength > 10000 ? (
-                <div className="text-xs text-red-600">60–10000</div>
-              ) : null}
-            </label>
-          </div>
-        );
-      case "analyzer":
-        return (
-          <div className="space-y-4">
-            <label className="block text-sm">
-              Sampling interval (sec)
-              <input
-                type="number"
-                className="mt-1 border rounded-md px-2 py-1 w-full"
-                value={local.analyzer.samplingSec}
-                onChange={(e) =>
-                  handleField("analyzer", "samplingSec", parseFloat(e.target.value || 0))
-                }
-                step="0.1"
-                min="0.2"
-              />
-              {local.analyzer.samplingSec < 0.2 || local.analyzer.samplingSec > 60 ? (
-                <div className="text-xs text-red-600">0.2–60</div>
-              ) : null}
-            </label>
-            <label className="flex items-center gap-2 text-sm">
-              <input
-                type="checkbox"
-                checked={local.analyzer.autostart}
-                onChange={(e) => handleField("analyzer", "autostart", e.target.checked)}
-              />
-              Autostart analyzer
-            </label>
-            <label className="flex items-center gap-2 text-sm">
-              <input
-                type="checkbox"
-                checked={local.analyzer.showZeroReminder}
-                onChange={(e) => handleField("analyzer", "showZeroReminder", e.target.checked)}
-              />
-              Show zero reminder
-            </label>
-          </div>
-        );
-      case "units":
-        return (
-          <div className="space-y-4">
-            <label className="block text-sm">
-              Unit system
-              <select
-                className="mt-1 border rounded-md px-2 py-1 w-full"
-                value={local.units.system}
-                onChange={(e) => handleField("units", "system", e.target.value)}
-              >
-                <option value="imperial">Imperial</option>
-                <option value="metric">Metric</option>
-              </select>
-            </label>
-          </div>
-        );
-      case "ambient":
-        return (
-          <div className="space-y-4">
-            <label className="flex items-center gap-2 text-sm">
-              <input
-                type="checkbox"
-                checked={local.ambient.live}
-                onChange={(e) => handleField("ambient", "live", e.target.checked)}
-              />
-              Use live ambient data
-            </label>
-            <label className="block text-sm">
-              Default ZIP
-              <input
-                type="text"
-                className="mt-1 border rounded-md px-2 py-1 w-full"
-                value={local.ambient.defaultZip}
-                onChange={(e) => handleField("ambient", "defaultZip", e.target.value)}
-              />
-            </label>
-            <label className="block text-sm">
-              Ambient API base URL
-              <input
-                type="text"
-                className="mt-1 border rounded-md px-2 py-1 w-full"
-                value={local.ambient.baseUrl}
-                onChange={(e) => handleField("ambient", "baseUrl", e.target.value)}
-              />
-            </label>
-            <label className="block text-sm">
-              ZIP geocode base URL
-              <input
-                type="text"
-                className="mt-1 border rounded-md px-2 py-1 w-full"
-                value={local.ambient.zipGeoBaseUrl}
-                onChange={(e) => handleField("ambient", "zipGeoBaseUrl", e.target.value)}
-              />
-            </label>
-            <div className="text-xs text-slate-500">
-              Live ambient will be wired in a later update using <code>zipToAmbient</code>.
-            </div>
-          </div>
-        );
-      case "data":
-        return (
-          <div className="space-y-4 text-sm">
-            <p>
-              Data export and import buttons remain in the header for now and will
-              move here in a follow‑up.
-            </p>
-          </div>
-        );
-      default:
-        return null;
-    }
-  };
+  const SectionComponent = sections[section]?.Component;
 
   if (!open) return null;
 
@@ -233,22 +86,27 @@ export default function SettingsMenu({ open, config, onApply, onCancel }) {
         <div className="flex-1 flex">
           <nav className="w-40 border-r p-4 hidden sm:block" aria-label="Settings sections">
             <ul className="space-y-2">
-              {sections.map((s) => (
-                <li key={s.key}>
+              {Object.entries(sections).map(([key, { label }]) => (
+                <li key={key}>
                   <button
                     className={`text-left w-full px-2 py-1 rounded-md ${
-                      section === s.key ? "bg-slate-200" : ""
+                      section === key ? "bg-slate-200" : ""
                     }`}
-                    onClick={() => setSection(s.key)}
+                    onClick={() => setSection(key)}
                   >
-                    {s.label}
+                    {label}
                   </button>
                 </li>
               ))}
             </ul>
           </nav>
           <div className="flex-1 p-4 overflow-y-auto">
-            {renderSection()}
+            {SectionComponent && (
+              <SectionComponent
+                values={local[section]}
+                onChange={(field, value) => handleField(section, field, value)}
+              />
+            )}
             <div className="mt-6 flex items-center justify-between">
               <button className="btn" onClick={handleReset}>
                 Restore defaults

--- a/src/components/SettingsMenu.jsx
+++ b/src/components/SettingsMenu.jsx
@@ -1,0 +1,270 @@
+import React, { useEffect, useRef, useState } from "react";
+import { getDefaultConfig } from "../lib/config";
+
+export default function SettingsMenu({ open, config, onApply, onCancel }) {
+  const [local, setLocal] = useState(config);
+  const [section, setSection] = useState("general");
+  const modalRef = useRef(null);
+
+  useEffect(() => {
+    if (open) {
+      setLocal(config);
+      // focus first focusable element
+      const focusable = modalRef.current?.querySelectorAll(
+        "button, [href], input, select, textarea, [tabindex]:not([tabindex='-1'])"
+      );
+      focusable && focusable[0]?.focus();
+    }
+  }, [open, config]);
+
+  // ESC to close and basic focus trap
+  useEffect(() => {
+    if (!open) return;
+    const handleKey = (e) => {
+      if (e.key === "Escape") onCancel();
+      if (e.key === "Tab") {
+        const focusable = modalRef.current?.querySelectorAll(
+          "button, [href], input, select, textarea, [tabindex]:not([tabindex='-1'])"
+        );
+        if (!focusable || focusable.length === 0) return;
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (e.shiftKey && document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        } else if (!e.shiftKey && document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    };
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [open, onCancel]);
+
+  const sections = [
+    { key: "general", label: "General" },
+    { key: "analyzer", label: "Analyzer" },
+    { key: "units", label: "Units" },
+    { key: "ambient", label: "Ambient" },
+    { key: "data", label: "Data and privacy" },
+  ];
+
+  const handleField = (sec, field, value) => {
+    setLocal((p) => ({ ...p, [sec]: { ...p[sec], [field]: value } }));
+  };
+
+  const handleReset = () => {
+    if (!window.confirm("Reset this section to defaults?")) return;
+    const defaults = getDefaultConfig();
+    setLocal((p) => ({ ...p, [section]: defaults[section] }));
+  };
+
+  const renderSection = () => {
+    switch (section) {
+      case "general":
+        return (
+          <div className="space-y-4">
+            <label className="block text-sm">
+              Theme
+              <select
+                className="mt-1 border rounded-md px-2 py-1 w-full"
+                value={local.general.theme}
+                onChange={(e) => handleField("general", "theme", e.target.value)}
+              >
+                <option value="light">Light</option>
+                <option value="dark">Dark</option>
+                <option value="system">System</option>
+              </select>
+            </label>
+            <label className="block text-sm">
+              Default view
+              <select
+                className="mt-1 border rounded-md px-2 py-1 w-full"
+                value={local.general.defaultView}
+                onChange={(e) => handleField("general", "defaultView", e.target.value)}
+              >
+                <option value="main">Main</option>
+                <option value="techDrawer">Technician drawer</option>
+              </select>
+            </label>
+            <label className="block text-sm">
+              Trend length (samples)
+              <input
+                type="number"
+                className="mt-1 border rounded-md px-2 py-1 w-full"
+                value={local.general.trendLength}
+                onChange={(e) =>
+                  handleField("general", "trendLength", parseInt(e.target.value || 0, 10))
+                }
+              />
+              {local.general.trendLength < 60 || local.general.trendLength > 10000 ? (
+                <div className="text-xs text-red-600">60–10000</div>
+              ) : null}
+            </label>
+          </div>
+        );
+      case "analyzer":
+        return (
+          <div className="space-y-4">
+            <label className="block text-sm">
+              Sampling interval (sec)
+              <input
+                type="number"
+                className="mt-1 border rounded-md px-2 py-1 w-full"
+                value={local.analyzer.samplingSec}
+                onChange={(e) =>
+                  handleField("analyzer", "samplingSec", parseFloat(e.target.value || 0))
+                }
+                step="0.1"
+                min="0.2"
+              />
+              {local.analyzer.samplingSec < 0.2 || local.analyzer.samplingSec > 60 ? (
+                <div className="text-xs text-red-600">0.2–60</div>
+              ) : null}
+            </label>
+            <label className="flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                checked={local.analyzer.autostart}
+                onChange={(e) => handleField("analyzer", "autostart", e.target.checked)}
+              />
+              Autostart analyzer
+            </label>
+            <label className="flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                checked={local.analyzer.showZeroReminder}
+                onChange={(e) => handleField("analyzer", "showZeroReminder", e.target.checked)}
+              />
+              Show zero reminder
+            </label>
+          </div>
+        );
+      case "units":
+        return (
+          <div className="space-y-4">
+            <label className="block text-sm">
+              Unit system
+              <select
+                className="mt-1 border rounded-md px-2 py-1 w-full"
+                value={local.units.system}
+                onChange={(e) => handleField("units", "system", e.target.value)}
+              >
+                <option value="imperial">Imperial</option>
+                <option value="metric">Metric</option>
+              </select>
+            </label>
+          </div>
+        );
+      case "ambient":
+        return (
+          <div className="space-y-4">
+            <label className="flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                checked={local.ambient.live}
+                onChange={(e) => handleField("ambient", "live", e.target.checked)}
+              />
+              Use live ambient data
+            </label>
+            <label className="block text-sm">
+              Default ZIP
+              <input
+                type="text"
+                className="mt-1 border rounded-md px-2 py-1 w-full"
+                value={local.ambient.defaultZip}
+                onChange={(e) => handleField("ambient", "defaultZip", e.target.value)}
+              />
+            </label>
+            <label className="block text-sm">
+              Ambient API base URL
+              <input
+                type="text"
+                className="mt-1 border rounded-md px-2 py-1 w-full"
+                value={local.ambient.baseUrl}
+                onChange={(e) => handleField("ambient", "baseUrl", e.target.value)}
+              />
+            </label>
+            <label className="block text-sm">
+              ZIP geocode base URL
+              <input
+                type="text"
+                className="mt-1 border rounded-md px-2 py-1 w-full"
+                value={local.ambient.zipGeoBaseUrl}
+                onChange={(e) => handleField("ambient", "zipGeoBaseUrl", e.target.value)}
+              />
+            </label>
+            <div className="text-xs text-slate-500">
+              Live ambient will be wired in a later update using <code>zipToAmbient</code>.
+            </div>
+          </div>
+        );
+      case "data":
+        return (
+          <div className="space-y-4 text-sm">
+            <p>
+              Data export and import buttons remain in the header for now and will
+              move here in a follow‑up.
+            </p>
+          </div>
+        );
+      default:
+        return null;
+    }
+  };
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div
+        ref={modalRef}
+        className="bg-white w-full h-full sm:h-auto sm:max-w-3xl sm:rounded-md sm:flex"
+        role="dialog"
+        aria-modal="true"
+      >
+        <div className="sm:hidden flex items-center justify-between p-4 border-b">
+          <h2 className="text-lg font-semibold">Settings</h2>
+          <button className="btn" onClick={onCancel} aria-label="Close settings">
+            Close
+          </button>
+        </div>
+        <div className="flex-1 flex">
+          <nav className="w-40 border-r p-4 hidden sm:block" aria-label="Settings sections">
+            <ul className="space-y-2">
+              {sections.map((s) => (
+                <li key={s.key}>
+                  <button
+                    className={`text-left w-full px-2 py-1 rounded-md ${
+                      section === s.key ? "bg-slate-200" : ""
+                    }`}
+                    onClick={() => setSection(s.key)}
+                  >
+                    {s.label}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </nav>
+          <div className="flex-1 p-4 overflow-y-auto">
+            {renderSection()}
+            <div className="mt-6 flex items-center justify-between">
+              <button className="btn" onClick={handleReset}>
+                Restore defaults
+              </button>
+              <div className="flex gap-2">
+                <button className="btn" onClick={onCancel}>
+                  Cancel
+                </button>
+                <button className="btn btn-primary" onClick={() => onApply(local)}>
+                  Apply
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/settings/AmbientSection.jsx
+++ b/src/components/settings/AmbientSection.jsx
@@ -1,0 +1,46 @@
+import React from "react";
+
+export default function AmbientSection({ values, onChange }) {
+  return (
+    <div className="space-y-4">
+      <label className="flex items-center gap-2 text-sm">
+        <input
+          type="checkbox"
+          checked={values.live}
+          onChange={(e) => onChange("live", e.target.checked)}
+        />
+        Use live ambient data
+      </label>
+      <label className="block text-sm">
+        Default ZIP
+        <input
+          type="text"
+          className="mt-1 border rounded-md px-2 py-1 w-full"
+          value={values.defaultZip}
+          onChange={(e) => onChange("defaultZip", e.target.value)}
+        />
+      </label>
+      <label className="block text-sm">
+        Ambient API base URL
+        <input
+          type="text"
+          className="mt-1 border rounded-md px-2 py-1 w-full"
+          value={values.baseUrl}
+          onChange={(e) => onChange("baseUrl", e.target.value)}
+        />
+      </label>
+      <label className="block text-sm">
+        ZIP geocode base URL
+        <input
+          type="text"
+          className="mt-1 border rounded-md px-2 py-1 w-full"
+          value={values.zipGeoBaseUrl}
+          onChange={(e) => onChange("zipGeoBaseUrl", e.target.value)}
+        />
+      </label>
+      <div className="text-xs text-slate-500">
+        Live ambient will be wired in a later update using <code>zipToAmbient</code>.
+      </div>
+    </div>
+  );
+}

--- a/src/components/settings/AnalyzerSection.jsx
+++ b/src/components/settings/AnalyzerSection.jsx
@@ -1,0 +1,38 @@
+import React from "react";
+
+export default function AnalyzerSection({ values, onChange }) {
+  return (
+    <div className="space-y-4">
+      <label className="block text-sm">
+        Sampling interval (sec)
+        <input
+          type="number"
+          className="mt-1 border rounded-md px-2 py-1 w-full"
+          value={values.samplingSec}
+          onChange={(e) => onChange("samplingSec", parseFloat(e.target.value || 0))}
+          step="0.1"
+          min="0.2"
+        />
+        {values.samplingSec < 0.2 || values.samplingSec > 60 ? (
+          <div className="text-xs text-red-600">0.2–60</div>
+        ) : null}
+      </label>
+      <label className="flex items-center gap-2 text-sm">
+        <input
+          type="checkbox"
+          checked={values.autostart}
+          onChange={(e) => onChange("autostart", e.target.checked)}
+        />
+        Autostart analyzer
+      </label>
+      <label className="flex items-center gap-2 text-sm">
+        <input
+          type="checkbox"
+          checked={values.showZeroReminder}
+          onChange={(e) => onChange("showZeroReminder", e.target.checked)}
+        />
+        Show zero reminder
+      </label>
+    </div>
+  );
+}

--- a/src/components/settings/DataSection.jsx
+++ b/src/components/settings/DataSection.jsx
@@ -1,0 +1,12 @@
+import React from "react";
+
+export default function DataSection() {
+  return (
+    <div className="space-y-4 text-sm">
+      <p>
+        Data export and import buttons remain in the header for now and will move here in a
+        follow‑up.
+      </p>
+    </div>
+  );
+}

--- a/src/components/settings/GeneralSection.jsx
+++ b/src/components/settings/GeneralSection.jsx
@@ -1,0 +1,43 @@
+import React from "react";
+
+export default function GeneralSection({ values, onChange }) {
+  return (
+    <div className="space-y-4">
+      <label className="block text-sm">
+        Theme
+        <select
+          className="mt-1 border rounded-md px-2 py-1 w-full"
+          value={values.theme}
+          onChange={(e) => onChange("theme", e.target.value)}
+        >
+          <option value="light">Light</option>
+          <option value="dark">Dark</option>
+          <option value="system">System</option>
+        </select>
+      </label>
+      <label className="block text-sm">
+        Default view
+        <select
+          className="mt-1 border rounded-md px-2 py-1 w-full"
+          value={values.defaultView}
+          onChange={(e) => onChange("defaultView", e.target.value)}
+        >
+          <option value="main">Main</option>
+          <option value="techDrawer">Technician drawer</option>
+        </select>
+      </label>
+      <label className="block text-sm">
+        Trend length (samples)
+        <input
+          type="number"
+          className="mt-1 border rounded-md px-2 py-1 w-full"
+          value={values.trendLength}
+          onChange={(e) => onChange("trendLength", parseInt(e.target.value || 0, 10))}
+        />
+        {values.trendLength < 60 || values.trendLength > 10000 ? (
+          <div className="text-xs text-red-600">60–10000</div>
+        ) : null}
+      </label>
+    </div>
+  );
+}

--- a/src/components/settings/UnitsSection.jsx
+++ b/src/components/settings/UnitsSection.jsx
@@ -1,0 +1,19 @@
+import React from "react";
+
+export default function UnitsSection({ values, onChange }) {
+  return (
+    <div className="space-y-4">
+      <label className="block text-sm">
+        Unit system
+        <select
+          className="mt-1 border rounded-md px-2 py-1 w-full"
+          value={values.system}
+          onChange={(e) => onChange("system", e.target.value)}
+        >
+          <option value="imperial">Imperial</option>
+          <option value="metric">Metric</option>
+        </select>
+      </label>
+    </div>
+  );
+}

--- a/src/lib/ambient.js
+++ b/src/lib/ambient.js
@@ -1,0 +1,33 @@
+/**
+ * Utility helpers for ambient weather data.
+ * Live ambient wiring will be implemented in a later phase.
+ */
+
+/**
+ * Convert a ZIP code to ambient conditions using public providers.
+ *
+ * @param {string} zip
+ * @param {string} baseUrl - Open-Meteo endpoint
+ * @param {string} zipGeoBaseUrl - Zippopotam endpoint
+ * @returns {Promise<{tempF:number,rh:number,pressure:number}>}
+ */
+export async function zipToAmbient(zip, baseUrl, zipGeoBaseUrl) {
+  // Look up latitude and longitude for the ZIP
+  const geoRes = await fetch(`${zipGeoBaseUrl}/${zip}`);
+  const geo = await geoRes.json();
+  const place = geo?.places?.[0];
+  if (!place) throw new Error("Invalid ZIP code");
+  const { latitude, longitude } = place;
+
+  // Fetch current temperature, humidity, and pressure
+  const url = `${baseUrl}?latitude=${latitude}&longitude=${longitude}&current=temperature_2m,relative_humidity_2m,pressure_msl`;
+  const weatherRes = await fetch(url);
+  const weather = await weatherRes.json();
+  const cur = weather.current || {};
+
+  const tempF = cur.temperature_2m * 9 / 5 + 32;
+  const rh = cur.relative_humidity_2m;
+  const pressure = cur.pressure_msl * 0.02953; // hPa → inHg
+
+  return { tempF, rh, pressure };
+}

--- a/src/lib/ambient.js
+++ b/src/lib/ambient.js
@@ -14,6 +14,7 @@
 export async function zipToAmbient(zip, baseUrl, zipGeoBaseUrl) {
   // Look up latitude and longitude for the ZIP
   const geoRes = await fetch(`${zipGeoBaseUrl}/${zip}`);
+  if (!geoRes.ok) throw new Error(`Failed to fetch geo data for ZIP ${zip}: ${geoRes.statusText}`);
   const geo = await geoRes.json();
   const place = geo?.places?.[0];
   if (!place) throw new Error("Invalid ZIP code");

--- a/src/lib/ambient.js
+++ b/src/lib/ambient.js
@@ -23,6 +23,7 @@ export async function zipToAmbient(zip, baseUrl, zipGeoBaseUrl) {
   // Fetch current temperature, humidity, and pressure
   const url = `${baseUrl}?latitude=${latitude}&longitude=${longitude}&current=temperature_2m,relative_humidity_2m,pressure_msl`;
   const weatherRes = await fetch(url);
+  if (!weatherRes.ok) throw new Error(`Failed to fetch weather data: ${weatherRes.statusText}`);
   const weather = await weatherRes.json();
   const cur = weather.current || {};
 

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -64,7 +64,7 @@ export function saveConfig(cfg) {
   try {
     const valid = validateConfig(cfg);
     localStorage.setItem(STORAGE_KEY, JSON.stringify(valid));
-  } catch {
-    // ignore
+  } catch (error) {
+    console.error("Failed to save config to localStorage:", error);
   }
 }

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -1,0 +1,70 @@
+import { clamp } from "./math";
+
+const defaultConfig = {
+  general: {
+    theme: "light",
+    defaultView: "main",
+    trendLength: 600,
+  },
+  analyzer: {
+    samplingSec: 1,
+    autostart: false,
+    showZeroReminder: true,
+  },
+  units: {
+    system: "imperial",
+  },
+  ambient: {
+    live: false,
+    defaultZip: "11215",
+    baseUrl: "https://api.open-meteo.com/v1/forecast",
+    zipGeoBaseUrl: "https://api.zippopotam.us/us",
+  },
+  data: {},
+};
+
+export function getDefaultConfig() {
+  // Return a deep clone to avoid mutation of the default object
+  return JSON.parse(JSON.stringify(defaultConfig));
+}
+
+export function validateConfig(partial = {}) {
+  const base = getDefaultConfig();
+  const cfg = {
+    ...base,
+    ...partial,
+    general: { ...base.general, ...partial.general },
+    analyzer: { ...base.analyzer, ...partial.analyzer },
+    units: { ...base.units, ...partial.units },
+    ambient: { ...base.ambient, ...partial.ambient },
+    data: { ...base.data, ...partial.data },
+  };
+
+  // Clamp numeric fields to reasonable ranges
+  cfg.general.trendLength = clamp(cfg.general.trendLength, 60, 10000);
+  cfg.analyzer.samplingSec = clamp(cfg.analyzer.samplingSec, 0.2, 60);
+
+  return cfg;
+}
+
+const STORAGE_KEY = "app_config_v1";
+
+export function loadConfig() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    return validateConfig(parsed);
+  } catch {
+    return null;
+  }
+}
+
+export function saveConfig(cfg) {
+  try {
+    const valid = validateConfig(cfg);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(valid));
+  } catch {
+    // ignore
+  }
+}

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -33,11 +33,11 @@ export function validateConfig(partial = {}) {
   const cfg = {
     ...base,
     ...partial,
-    general: { ...base.general, ...partial.general },
-    analyzer: { ...base.analyzer, ...partial.analyzer },
-    units: { ...base.units, ...partial.units },
-    ambient: { ...base.ambient, ...partial.ambient },
-    data: { ...base.data, ...partial.data },
+    general: { ...base.general, ...(partial.general || {}) },
+    analyzer: { ...base.analyzer, ...(partial.analyzer || {}) },
+    units: { ...base.units, ...(partial.units || {}) },
+    ambient: { ...base.ambient, ...(partial.ambient || {}) },
+    data: { ...base.data, ...(partial.data || {}) },
   };
 
   // Clamp numeric fields to reasonable ranges


### PR DESCRIPTION
## Summary
- add configurable Settings menu with sections for general, analyzer, units, ambient, and data
- persist options to `app_config_v1` and apply theme and units immediately
- document new Settings workflow in README

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a746bc8f8832aae7c7e04df76eb8e