### PR TITLE
refactor: use component map for settings

### DIFF
--- a/src/components/SettingsMenu.jsx
+++ b/src/components/SettingsMenu.jsx
@@ -1,5 +1,10 @@
 import React, { useEffect, useRef, useState } from "react";
 import { getDefaultConfig } from "../lib/config";
+import GeneralSection from "./settings/GeneralSection.jsx";
+import AnalyzerSection from "./settings/AnalyzerSection.jsx";
+import UnitsSection from "./settings/UnitsSection.jsx";
+import AmbientSection from "./settings/AmbientSection.jsx";
+import DataSection from "./settings/DataSection.jsx";
 
 export default function SettingsMenu({ open, config, onApply, onCancel }) {
   const [local, setLocal] = useState(config);
@@ -42,13 +47,13 @@ export default function SettingsMenu({ open, config, onApply, onCancel }) {
     return () => document.removeEventListener("keydown", handleKey);
   }, [open, onCancel]);
 
-  const sections = [
-    { key: "general", label: "General" },
-    { key: "analyzer", label: "Analyzer" },
-    { key: "units", label: "Units" },
-    { key: "ambient", label: "Ambient" },
-    { key: "data", label: "Data and privacy" },
-  ];
+  const sections = {
+    general: { label: "General", Component: GeneralSection },
+    analyzer: { label: "Analyzer", Component: AnalyzerSection },
+    units: { label: "Units", Component: UnitsSection },
+    ambient: { label: "Ambient", Component: AmbientSection },
+    data: { label: "Data and privacy", Component: DataSection },
+  };
 
   const handleField = (sec, field, value) => {
     setLocal((p) => ({ ...p, [sec]: { ...p[sec], [field]: value } }));
@@ -60,159 +65,7 @@ export default function SettingsMenu({ open, config, onApply, onCancel }) {
     setLocal((p) => ({ ...p, [section]: defaults[section] }));
   };
 
-  const renderSection = () => {
-    switch (section) {
-      case "general":
-        return (
-          <div className="space-y-4">
-            <label className="block text-sm">
-              Theme
-              <select
-                className="mt-1 border rounded-md px-2 py-1 w-full"
-                value={local.general.theme}
-                onChange={(e) => handleField("general", "theme", e.target.value)}
-              >
-                <option value="light">Light</option>
-                <option value="dark">Dark</option>
-                <option value="system">System</option>
-              </select>
-            </label>
-            <label className="block text-sm">
-              Default view
-              <select
-                className="mt-1 border rounded-md px-2 py-1 w-full"
-                value={local.general.defaultView}
-                onChange={(e) => handleField("general", "defaultView", e.target.value)}
-              >
-                <option value="main">Main</option>
-                <option value="techDrawer">Technician drawer</option>
-              </select>
-            </label>
-            <label className="block text-sm">
-              Trend length (samples)
-              <input
-                type="number"
-                className="mt-1 border rounded-md px-2 py-1 w-full"
-                value={local.general.trendLength}
-                onChange={(e) =>
-                  handleField("general", "trendLength", parseInt(e.target.value || 0, 10))
-                }
-              />
-              {local.general.trendLength < 60 || local.general.trendLength > 10000 ? (
-                <div className="text-xs text-red-600">60–10000</div>
-              ) : null}
-            </label>
-          </div>
-        );
-      case "analyzer":
-        return (
-          <div className="space-y-4">
-            <label className="block text-sm">
-              Sampling interval (sec)
-              <input
-                type="number"
-                className="mt-1 border rounded-md px-2 py-1 w-full"
-                value={local.analyzer.samplingSec}
-                onChange={(e) =>
-                  handleField("analyzer", "samplingSec", parseFloat(e.target.value || 0))
-                }
-                step="0.1"
-                min="0.2"
-              />
-              {local.analyzer.samplingSec < 0.2 || local.analyzer.samplingSec > 60 ? (
-                <div className="text-xs text-red-600">0.2–60</div>
-              ) : null}
-            </label>
-            <label className="flex items-center gap-2 text-sm">
-              <input
-                type="checkbox"
-                checked={local.analyzer.autostart}
-                onChange={(e) => handleField("analyzer", "autostart", e.target.checked)}
-              />
-              Autostart analyzer
-            </label>
-            <label className="flex items-center gap-2 text-sm">
-              <input
-                type="checkbox"
-                checked={local.analyzer.showZeroReminder}
-                onChange={(e) => handleField("analyzer", "showZeroReminder", e.target.checked)}
-              />
-              Show zero reminder
-            </label>
-          </div>
-        );
-      case "units":
-        return (
-          <div className="space-y-4">
-            <label className="block text-sm">
-              Unit system
-              <select
-                className="mt-1 border rounded-md px-2 py-1 w-full"
-                value={local.units.system}
-                onChange={(e) => handleField("units", "system", e.target.value)}
-              >
-                <option value="imperial">Imperial</option>
-                <option value="metric">Metric</option>
-              </select>
-            </label>
-          </div>
-        );
-      case "ambient":
-        return (
-          <div className="space-y-4">
-            <label className="flex items-center gap-2 text-sm">
-              <input
-                type="checkbox"
-                checked={local.ambient.live}
-                onChange={(e) => handleField("ambient", "live", e.target.checked)}
-              />
-              Use live ambient data
-            </label>
-            <label className="block text-sm">
-              Default ZIP
-              <input
-                type="text"
-                className="mt-1 border rounded-md px-2 py-1 w-full"
-                value={local.ambient.defaultZip}
-                onChange={(e) => handleField("ambient", "defaultZip", e.target.value)}
-              />
-            </label>
-            <label className="block text-sm">
-              Ambient API base URL
-              <input
-                type="text"
-                className="mt-1 border rounded-md px-2 py-1 w-full"
-                value={local.ambient.baseUrl}
-                onChange={(e) => handleField("ambient", "baseUrl", e.target.value)}
-              />
-            </label>
-            <label className="block text-sm">
-              ZIP geocode base URL
-              <input
-                type="text"
-                className="mt-1 border rounded-md px-2 py-1 w-full"
-                value={local.ambient.zipGeoBaseUrl}
-                onChange={(e) => handleField("ambient", "zipGeoBaseUrl", e.target.value)}
-              />
-            </label>
-            <div className="text-xs text-slate-500">
-              Live ambient will be wired in a later update using <code>zipToAmbient</code>.
-            </div>
-          </div>
-        );
-      case "data":
-        return (
-          <div className="space-y-4 text-sm">
-            <p>
-              Data export and import buttons remain in the header for now and will
-              move here in a follow‑up.
-            </p>
-          </div>
-        );
-      default:
-        return null;
-    }
-  };
+  const SectionComponent = sections[section]?.Component;
 
   if (!open) return null;
 
@@ -233,22 +86,27 @@ export default function SettingsMenu({ open, config, onApply, onCancel }) {
         <div className="flex-1 flex">
           <nav className="w-40 border-r p-4 hidden sm:block" aria-label="Settings sections">
             <ul className="space-y-2">
-              {sections.map((s) => (
-                <li key={s.key}>
+              {Object.entries(sections).map(([key, { label }]) => (
+                <li key={key}>
                   <button
                     className={`text-left w-full px-2 py-1 rounded-md ${
-                      section === s.key ? "bg-slate-200" : ""
+                      section === key ? "bg-slate-200" : ""
                     }`}
-                    onClick={() => setSection(s.key)}
+                    onClick={() => setSection(key)}
                   >
-                    {s.label}
+                    {label}
                   </button>
                 </li>
               ))}
             </ul>
           </nav>
           <div className="flex-1 p-4 overflow-y-auto">
-            {renderSection()}
+            {SectionComponent && (
+              <SectionComponent
+                values={local[section]}
+                onChange={(field, value) => handleField(section, field, value)}
+              />
+            )}
             <div className="mt-6 flex items-center justify-between">
               <button className="btn" onClick={handleReset}>
                 Restore defaults

--- a/src/components/settings/AmbientSection.jsx
+++ b/src/components/settings/AmbientSection.jsx
@@ -1,0 +1,46 @@
+import React from "react";
+
+export default function AmbientSection({ values, onChange }) {
+  return (
+    <div className="space-y-4">
+      <label className="flex items-center gap-2 text-sm">
+        <input
+          type="checkbox"
+          checked={values.live}
+          onChange={(e) => onChange("live", e.target.checked)}
+        />
+        Use live ambient data
+      </label>
+      <label className="block text-sm">
+        Default ZIP
+        <input
+          type="text"
+          className="mt-1 border rounded-md px-2 py-1 w-full"
+          value={values.defaultZip}
+          onChange={(e) => onChange("defaultZip", e.target.value)}
+        />
+      </label>
+      <label className="block text-sm">
+        Ambient API base URL
+        <input
+          type="text"
+          className="mt-1 border rounded-md px-2 py-1 w-full"
+          value={values.baseUrl}
+          onChange={(e) => onChange("baseUrl", e.target.value)}
+        />
+      </label>
+      <label className="block text-sm">
+        ZIP geocode base URL
+        <input
+          type="text"
+          className="mt-1 border rounded-md px-2 py-1 w-full"
+          value={values.zipGeoBaseUrl}
+          onChange={(e) => onChange("zipGeoBaseUrl", e.target.value)}
+        />
+      </label>
+      <div className="text-xs text-slate-500">
+        Live ambient will be wired in a later update using <code>zipToAmbient</code>.
+      </div>
+    </div>
+  );
+}

--- a/src/components/settings/AnalyzerSection.jsx
+++ b/src/components/settings/AnalyzerSection.jsx
@@ -1,0 +1,38 @@
+import React from "react";
+
+export default function AnalyzerSection({ values, onChange }) {
+  return (
+    <div className="space-y-4">
+      <label className="block text-sm">
+        Sampling interval (sec)
+        <input
+          type="number"
+          className="mt-1 border rounded-md px-2 py-1 w-full"
+          value={values.samplingSec}
+          onChange={(e) => onChange("samplingSec", parseFloat(e.target.value || 0))}
+          step="0.1"
+          min="0.2"
+        />
+        {values.samplingSec < 0.2 || values.samplingSec > 60 ? (
+          <div className="text-xs text-red-600">0.2–60</div>
+        ) : null}
+      </label>
+      <label className="flex items-center gap-2 text-sm">
+        <input
+          type="checkbox"
+          checked={values.autostart}
+          onChange={(e) => onChange("autostart", e.target.checked)}
+        />
+        Autostart analyzer
+      </label>
+      <label className="flex items-center gap-2 text-sm">
+        <input
+          type="checkbox"
+          checked={values.showZeroReminder}
+          onChange={(e) => onChange("showZeroReminder", e.target.checked)}
+        />
+        Show zero reminder
+      </label>
+    </div>
+  );
+}

--- a/src/components/settings/DataSection.jsx
+++ b/src/components/settings/DataSection.jsx
@@ -1,0 +1,12 @@
+import React from "react";
+
+export default function DataSection() {
+  return (
+    <div className="space-y-4 text-sm">
+      <p>
+        Data export and import buttons remain in the header for now and will move here in a
+        follow‑up.
+      </p>
+    </div>
+  );
+}

--- a/src/components/settings/GeneralSection.jsx
+++ b/src/components/settings/GeneralSection.jsx
@@ -1,0 +1,43 @@
+import React from "react";
+
+export default function GeneralSection({ values, onChange }) {
+  return (
+    <div className="space-y-4">
+      <label className="block text-sm">
+        Theme
+        <select
+          className="mt-1 border rounded-md px-2 py-1 w-full"
+          value={values.theme}
+          onChange={(e) => onChange("theme", e.target.value)}
+        >
+          <option value="light">Light</option>
+          <option value="dark">Dark</option>
+          <option value="system">System</option>
+        </select>
+      </label>
+      <label className="block text-sm">
+        Default view
+        <select
+          className="mt-1 border rounded-md px-2 py-1 w-full"
+          value={values.defaultView}
+          onChange={(e) => onChange("defaultView", e.target.value)}
+        >
+          <option value="main">Main</option>
+          <option value="techDrawer">Technician drawer</option>
+        </select>
+      </label>
+      <label className="block text-sm">
+        Trend length (samples)
+        <input
+          type="number"
+          className="mt-1 border rounded-md px-2 py-1 w-full"
+          value={values.trendLength}
+          onChange={(e) => onChange("trendLength", parseInt(e.target.value || 0, 10))}
+        />
+        {values.trendLength < 60 || values.trendLength > 10000 ? (
+          <div className="text-xs text-red-600">60–10000</div>
+        ) : null}
+      </label>
+    </div>
+  );
+}

--- a/src/components/settings/UnitsSection.jsx
+++ b/src/components/settings/UnitsSection.jsx
@@ -1,0 +1,19 @@
+import React from "react";
+
+export default function UnitsSection({ values, onChange }) {
+  return (
+    <div className="space-y-4">
+      <label className="block text-sm">
+        Unit system
+        <select
+          className="mt-1 border rounded-md px-2 py-1 w-full"
+          value={values.system}
+          onChange={(e) => onChange("system", e.target.value)}
+        >
+          <option value="imperial">Imperial</option>
+          <option value="metric">Metric</option>
+        </select>
+      </label>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- break out settings sections into dedicated components
- replace large switch with component map

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a782b0b18832a972a1a9ea37c4d96