### PR TITLE
feat: add foundational panel layout store

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@tailwindcss/vite": "^4.1.11",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
+        "react-grid-layout": "^1.5.2",
         "recharts": "^3.1.2",
         "tailwindcss": "^4.1.11"
       },
@@ -2421,6 +2422,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-equals": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-4.0.3.tgz",
+      "integrity": "sha512-G3BSX9cfKttjr+2o1O22tYMLq0DPluZnYtq1rXumE1SpL/F/SLIfHx08WYQoWSIpeMYf8sRbJ8++71+v6Pnxfg==",
+      "license": "MIT"
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -2665,7 +2672,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -3003,6 +3009,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -3109,6 +3127,15 @@
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -3249,6 +3276,23 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3278,6 +3322,38 @@
       },
       "peerDependencies": {
         "react": "^19.1.1"
+      }
+    },
+    "node_modules/react-draggable": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.5.0.tgz",
+      "integrity": "sha512-VC+HBLEZ0XJxnOxVAZsdRi8rD04Iz3SiiKOoYzamjylUcju/hP9np/aZdLHf/7WOD268WMoNJMvYfB5yAK45cw==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0",
+        "react-dom": ">= 16.3.0"
+      }
+    },
+    "node_modules/react-grid-layout": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/react-grid-layout/-/react-grid-layout-1.5.2.tgz",
+      "integrity": "sha512-vT7xmQqszTT+sQw/LfisrEO4le1EPNnSEMVHy6sBZyzS3yGkMywdOd+5iEFFwQwt0NSaGkxuRmYwa1JsP6OJdw==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1",
+        "fast-equals": "^4.0.3",
+        "prop-types": "^15.8.1",
+        "react-draggable": "^4.4.6",
+        "react-resizable": "^3.0.5",
+        "resize-observer-polyfill": "^1.5.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0",
+        "react-dom": ">= 16.3.0"
       }
     },
     "node_modules/react-is": {
@@ -3318,6 +3394,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-resizable": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/react-resizable/-/react-resizable-3.0.5.tgz",
+      "integrity": "sha512-vKpeHhI5OZvYn82kXOs1bC8aOXktGU5AmKAgaZS4F5JPburCtbmDPqE7Pzp+1kN4+Wb81LlF33VpGwWwtXem+w==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "15.x",
+        "react-draggable": "^4.0.3"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3"
       }
     },
     "node_modules/recharts": {
@@ -3366,6 +3455,12 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
       "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
+    },
+    "node_modules/resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
       "license": "MIT"
     },
     "node_modules/resolve-from": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@tailwindcss/vite": "^4.1.11",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
+    "react-grid-layout": "^1.5.2",
     "recharts": "^3.1.2",
     "tailwindcss": "^4.1.11"
   },

--- a/src/components/GridZone.jsx
+++ b/src/components/GridZone.jsx
@@ -1,0 +1,77 @@
+import React, { useEffect, useRef } from "react";
+import { Responsive, WidthProvider } from "react-grid-layout";
+import PanelShell from "./PanelShell";
+import { panels } from "../layout/panels";
+import {
+  useLayoutStore,
+  moveWithinZone,
+  moveAcrossZones,
+  zoneRefs,
+} from "../layout/store";
+import "react-grid-layout/css/styles.css";
+import "react-resizable/css/styles.css";
+
+const ResponsiveGridLayout = WidthProvider(Responsive);
+
+/**
+ * Wrapper around ResponsiveGridLayout that wires drag/resize events
+ * to the layout store and enables cross-zone moves.
+ */
+export default function GridZone({ zone }) {
+  const ref = useRef(null);
+  const layouts = useLayoutStore((s) => s.layouts[zone]);
+  const zoneById = useLayoutStore((s) => s.zoneById);
+
+  useEffect(() => {
+    zoneRefs[zone] = ref.current;
+    return () => {
+      zoneRefs[zone] = null;
+    };
+  }, [zone]);
+
+  const items = Object.keys(zoneById).filter((id) => zoneById[id] === zone);
+
+  const handleLayoutChange = (_, allLayouts) => {
+    moveWithinZone(zone, allLayouts);
+  };
+
+  const handleDragStop = (layout, oldItem, newItem, placeholder, e) => {
+    const centerX = e.clientX;
+    const centerY = e.clientY;
+    for (const [other, el] of Object.entries(zoneRefs)) {
+      if (other !== zone && el) {
+        const r = el.getBoundingClientRect();
+        if (centerX >= r.left && centerX <= r.right && centerY >= r.top && centerY <= r.bottom) {
+          moveAcrossZones(newItem.i, zone, other, { x: newItem.x, y: newItem.y, w: newItem.w, h: newItem.h });
+          return;
+        }
+      }
+    }
+    moveWithinZone(zone, { ...layouts, lg: layout });
+  };
+
+  return (
+    <div ref={ref} className="mb-4">
+      <ResponsiveGridLayout
+        layouts={layouts}
+        onLayoutChange={handleLayoutChange}
+        onDragStop={handleDragStop}
+        draggableHandle=".drag-handle"
+        isResizable
+        margin={[8, 8]}
+        compactType="vertical"
+      >
+        {items.map((id) => {
+          const Panel = panels[id].Component;
+          return (
+            <div key={id} data-grid={{}}>
+              <PanelShell id={id} title={panels[id].title}>
+                <Panel />
+              </PanelShell>
+            </div>
+          );
+        })}
+      </ResponsiveGridLayout>
+    </div>
+  );
+}

--- a/src/components/PanelShell.jsx
+++ b/src/components/PanelShell.jsx
@@ -1,0 +1,40 @@
+import React, { useState } from "react";
+import { moveAcrossZones } from "../layout/store";
+
+/**
+ * Generic wrapper providing drag handle and menu for movable panels.
+ * Keeps children mounted even when collapsed.
+ */
+export default function PanelShell({ id, title, children }) {
+  const [collapsed, setCollapsed] = useState(false);
+
+  const move = (zone) => moveAcrossZones(id, undefined, zone);
+
+  return (
+    <div className="panel-shell border rounded bg-white shadow-sm">
+      <div
+        className="flex items-center justify-between p-2 drag-handle cursor-move select-none"
+        aria-label="Drag to move panel"
+      >
+        <span className="font-medium text-sm">{title}</span>
+        <div className="flex gap-1 items-center">
+          <button
+            onClick={() => setCollapsed((c) => !c)}
+            className="text-xs px-1 py-0.5 border rounded"
+          >
+            {collapsed ? "Expand" : "Collapse"}
+          </button>
+          <details className="relative">
+            <summary className="cursor-pointer px-1 text-lg leading-none">⋮</summary>
+            <div className="absolute right-0 mt-1 bg-white border rounded shadow text-xs flex flex-col z-10">
+              <button className="px-2 py-1 text-left" onClick={() => move("mainWide")}>Move to Main wide</button>
+              <button className="px-2 py-1 text-left" onClick={() => move("mainNarrow")}>Move to Main narrow</button>
+              <button className="px-2 py-1 text-left" onClick={() => move("techDrawer")}>Move to Technician</button>
+            </div>
+          </details>
+        </div>
+      </div>
+      {!collapsed && <div className="p-2">{children}</div>}
+    </div>
+  );
+}

--- a/src/layout/panels.js
+++ b/src/layout/panels.js
@@ -1,0 +1,63 @@
+import React from "react";
+import SeriesVisibility from "../components/SeriesVisibility";
+
+// Placeholder component for panels not yet implemented
+const Placeholder = ({ label }) => (
+  <div className="p-2 text-center text-xs">{label}</div>
+);
+
+export const panels = {
+  fuelSelector: { title: "Fuel Selector", Component: () => <Placeholder label="Fuel Selector" /> },
+  boilerPower: { title: "Boiler Power", Component: () => <Placeholder label="Boiler Power" /> },
+  fireRate: { title: "Fire Rate", Component: () => <Placeholder label="Fire Rate" /> },
+  flows: { title: "Flows", Component: () => <Placeholder label="Flows" /> },
+  chamberViz: { title: "Chamber Viz", Component: () => <Placeholder label="Chamber Viz" /> },
+  readouts: { title: "Readouts", Component: () => <Placeholder label="Readouts" /> },
+  analyzer: { title: "Analyzer", Component: () => <Placeholder label="Analyzer" /> },
+  programmer: { title: "Programmer", Component: () => <Placeholder label="Programmer" /> },
+  tuningPanel: { title: "Tuning Panel", Component: () => <Placeholder label="Tuning" /> },
+  trendGraph: { title: "Trend Graph", Component: () => <Placeholder label="Trend Graph" /> },
+  trendTable: { title: "Trend Table", Component: () => <Placeholder label="Trend Table" /> },
+  savedReadings: { title: "Saved Readings", Component: () => <Placeholder label="Saved Readings" /> },
+  clockBoiler: { title: "Clock the Boiler", Component: () => <Placeholder label="Clock Boiler" /> },
+  seriesVisibility: { title: "Series Visibility", Component: SeriesVisibility },
+  ambientInputs: { title: "Ambient Inputs", Component: () => <Placeholder label="Ambient Inputs" /> },
+};
+
+const zoneOrder = {
+  mainWide: ["chamberViz", "boilerPower", "fireRate", "flows", "programmer", "tuningPanel"],
+  mainNarrow: ["readouts"],
+  techDrawer: [
+    "analyzer",
+    "trendGraph",
+    "trendTable",
+    "savedReadings",
+    "clockBoiler",
+    "ambientInputs",
+    "seriesVisibility",
+    "fuelSelector",
+  ],
+};
+
+export const defaultZoneById = Object.fromEntries(
+  Object.entries(zoneOrder).flatMap(([zone, ids]) => ids.map((id) => [id, zone]))
+);
+
+const breakpoints = ["lg", "md", "sm", "xs"];
+
+function buildLayouts(ids, cols) {
+  const out = { lg: [], md: [], sm: [], xs: [] };
+  ids.forEach((id, idx) => {
+    const base = { i: id, x: 0, y: idx * 2, w: cols, h: 2 };
+    breakpoints.forEach((bp) => {
+      out[bp].push({ ...base, w: bp === "xs" ? 1 : base.w });
+    });
+  });
+  return out;
+}
+
+export const defaultLayouts = {
+  mainWide: buildLayouts(zoneOrder.mainWide, 8),
+  mainNarrow: buildLayouts(zoneOrder.mainNarrow, 4),
+  techDrawer: buildLayouts(zoneOrder.techDrawer, 12),
+};

--- a/src/layout/store.js
+++ b/src/layout/store.js
@@ -1,0 +1,94 @@
+import { useSyncExternalStore } from "react";
+import { defaultLayouts, defaultZoneById } from "./panels";
+
+const KEY_MAIN_WIDE = "uiLayout_v2_mainWide";
+const KEY_MAIN_NARROW = "uiLayout_v2_mainNarrow";
+const KEY_TECH = "uiLayout_v2_tech";
+const KEY_ZONES = "uiLayout_v2_zones";
+
+function loadState() {
+  if (typeof window === "undefined") {
+    return { layouts: defaultLayouts, zoneById: defaultZoneById };
+  }
+  const parse = (key, fallback) => {
+    try {
+      const v = localStorage.getItem(key);
+      return v ? JSON.parse(v) : fallback;
+    } catch {
+      return fallback;
+    }
+  };
+  return {
+    layouts: {
+      mainWide: parse(KEY_MAIN_WIDE, defaultLayouts.mainWide),
+      mainNarrow: parse(KEY_MAIN_NARROW, defaultLayouts.mainNarrow),
+      techDrawer: parse(KEY_TECH, defaultLayouts.techDrawer),
+    },
+    zoneById: parse(KEY_ZONES, defaultZoneById),
+  };
+}
+
+const state = loadState();
+const listeners = new Set();
+
+function save() {
+  if (typeof window === "undefined") return;
+  localStorage.setItem(KEY_MAIN_WIDE, JSON.stringify(state.layouts.mainWide));
+  localStorage.setItem(KEY_MAIN_NARROW, JSON.stringify(state.layouts.mainNarrow));
+  localStorage.setItem(KEY_TECH, JSON.stringify(state.layouts.techDrawer));
+  localStorage.setItem(KEY_ZONES, JSON.stringify(state.zoneById));
+}
+
+function setState(partial) {
+  Object.assign(state, partial);
+  save();
+  listeners.forEach((l) => l());
+}
+
+export function useLayoutStore(sel) {
+  return useSyncExternalStore(
+    (listener) => {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    () => sel(state)
+  );
+}
+
+export function moveWithinZone(zone, layouts) {
+  setState({ layouts: { ...state.layouts, [zone]: layouts } });
+}
+
+export function moveAcrossZones(id, from, to, target) {
+  const layouts = { ...state.layouts };
+  if (from) {
+    Object.keys(layouts[from]).forEach((bp) => {
+      layouts[from][bp] = layouts[from][bp].filter((i) => i.i !== id);
+    });
+  }
+  const item = target || { x: 0, y: Infinity, w: 1, h: 1 };
+  Object.keys(layouts[to]).forEach((bp) => {
+    layouts[to][bp] = [
+      ...layouts[to][bp],
+      { i: id, x: item.x, y: item.y, w: item.w, h: item.h },
+    ];
+  });
+  const zoneById = { ...state.zoneById, [id]: to };
+  setState({ layouts, zoneById });
+}
+
+export function resetAllLayouts() {
+  if (typeof window !== "undefined") {
+    localStorage.removeItem(KEY_MAIN_WIDE);
+    localStorage.removeItem(KEY_MAIN_NARROW);
+    localStorage.removeItem(KEY_TECH);
+    localStorage.removeItem(KEY_ZONES);
+  }
+  setState({ layouts: defaultLayouts, zoneById: defaultZoneById });
+}
+
+export const zoneRefs = {
+  mainWide: null,
+  mainNarrow: null,
+  techDrawer: null,
+};


### PR DESCRIPTION
## Summary
- add react-grid-layout for draggable responsive panels
- introduce layout registry and store with localStorage persistence
- implement PanelShell and GridZone components with cross-zone drag hooks

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a81a6eddc832ab33de80979450ba6